### PR TITLE
histogram: expose FindBucket in Histogram API 

### DIFF
--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -260,6 +260,13 @@ type Histogram interface {
 	Observe(float64)
 }
 
+type HistogramInternal interface {
+	Histogram
+
+	ObserveInternal(float64, int)
+	FindBucket(v float64) int
+}
+
 // bucketLabel is used for the label that defines the upper bound of a
 // bucket of a histogram ("le" -> "less or equal").
 const bucketLabel = "le"
@@ -520,7 +527,7 @@ type HistogramVecOpts struct {
 // The returned implementation also implements ExemplarObserver. It is safe to
 // perform the corresponding type assertion. Exemplars are tracked separately
 // for each bucket.
-func NewHistogram(opts HistogramOpts) Histogram {
+func NewHistogram(opts HistogramOpts) HistogramInternal {
 	return newHistogram(
 		NewDesc(
 			BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),
@@ -532,7 +539,7 @@ func NewHistogram(opts HistogramOpts) Histogram {
 	)
 }
 
-func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogram {
+func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) HistogramInternal {
 	if len(desc.variableLabels.names) != len(labelValues) {
 		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels.names, labelValues))
 	}
@@ -764,15 +771,15 @@ func (h *histogram) Desc() *Desc {
 }
 
 func (h *histogram) Observe(v float64) {
-	h.observe(v, h.findBucket(v))
+	h.ObserveInternal(v, h.FindBucket(v))
 }
 
 // ObserveWithExemplar should not be called in a high-frequency setting
 // for a native histogram with configured exemplars. For this case,
 // the implementation isn't lock-free and might suffer from lock contention.
 func (h *histogram) ObserveWithExemplar(v float64, e Labels) {
-	i := h.findBucket(v)
-	h.observe(v, i)
+	i := h.FindBucket(v)
+	h.ObserveInternal(v, i)
 	h.updateExemplar(v, i, e)
 }
 
@@ -861,9 +868,9 @@ func (h *histogram) Write(out *dto.Metric) error {
 	return nil
 }
 
-// findBucket returns the index of the bucket for the provided value, or
+// FindBucket returns the index of the bucket for the provided value, or
 // len(h.upperBounds) for the +Inf bucket.
-func (h *histogram) findBucket(v float64) int {
+func (h *histogram) FindBucket(v float64) int {
 	n := len(h.upperBounds)
 	if n == 0 {
 		return 0
@@ -896,8 +903,8 @@ func (h *histogram) findBucket(v float64) int {
 	return sort.SearchFloat64s(h.upperBounds, v)
 }
 
-// observe is the implementation for Observe without the findBucket part.
-func (h *histogram) observe(v float64, bucket int) {
+// ObserveInternal is the implementation for Observe without the FindBucket part.
+func (h *histogram) ObserveInternal(v float64, bucket int) {
 	// Do not add to sparse buckets for NaN observations.
 	doSparse := h.nativeHistogramSchema > math.MinInt32 && !math.IsNaN(v)
 	// We increment h.countAndHotIdx so that the counter in the lower


### PR DESCRIPTION
In order to record observations into multiple histograms efficiently,
it is helpful to be able to execute the `findBucket` call on the
client-side and then use the bucket to update multiple histogram
instances.

This change makes `FindBucket` and `ObserveInternal` public and
introduces the `HistogramInternal` interface to expose them since
`Histogram` itself is implemented by many implementations we want to
avoid modifying.